### PR TITLE
attempts to correct path of csv file for stringificaiton docs

### DIFF
--- a/docs/Stringification.rst
+++ b/docs/Stringification.rst
@@ -10,7 +10,7 @@ What can be better than making byte arrays slightly more human readable!? We pro
 Implemented ``format`` values
 
 .. csv-table:: Implemented format values
-   :file: .\stringification-formats.csv
+   :file: stringification-formats.csv
    :header-rows: 1
 
 .. code-block:: c#


### PR DESCRIPTION
apparently "./" path will work locally, but didn't not work on read the docs. Removing path info and giving it as shot.

Associated with #12 